### PR TITLE
Remove bigint literals

### DIFF
--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -6,7 +6,7 @@ export function bitIndexBigInt(v: bigint): number {
 }
 
 export function toGindex(index: bigint, depth: number): Gindex {
-  const anchor = 1n << BigInt(depth);
+  const anchor = BigInt(1) << BigInt(depth);
   if (index >= anchor) {
     throw new Error("index too large for depth");
   }
@@ -28,14 +28,14 @@ export function countToDepth(count: bigint): number {
   if (count <= 1) {
     return 0;
   }
-  return (count-1n).toString(2).length;
+  return (count - BigInt(1)).toString(2).length;
 }
 
 /**
  * Iterate through Gindexes at a certain depth
  */
 export function iterateAtDepth(startIndex: bigint, count: bigint, depth: number): Iterable<Gindex> {
-  const anchor = 1n << BigInt(depth);
+  const anchor = BigInt(1) << BigInt(depth);
   if (startIndex + count >= anchor) {
     throw new Error("Too large for depth");
   }


### PR DESCRIPTION
Verified with `grep -rE "[0-9]n" src`

Using bigint literals precludes use of this library in environments that don't support bigint.
This is problematic b/c this library is used as an optional dependency in https://github.com/chainsafe/ssz for operating on merkle-tree-backed objects only.