### PR TITLE
Iterate nodes at depth

### DIFF
--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -60,31 +60,36 @@ export function iterateAtDepth(startIndex: bigint, count: bigint, depth: number)
 
 const ERR_INVALID_GINDEX = "Invalid gindex";
 
-export interface GindexIterator extends Iterable<number> {
+export type Bit = 0 | 1
+export interface GindexIterator extends Iterable<Bit> {
   remainingBitLength(): number;
-  totalBitLength(): number;
 }
 
-export function gindexIterator(gindex: Gindex): GindexIterator {
-  if (gindex < 1) {
-    throw new Error(ERR_INVALID_GINDEX);
+export function gindexIterator(gindex: Gindex | GindexBitstring): GindexIterator {
+  let bitstring: string;
+  if (typeof gindex === "string") {
+    if (!gindex.length) {
+      throw new Error(ERR_INVALID_GINDEX);
+    }
+    bitstring = gindex;
+  } else {
+    if (gindex < 1) {
+      throw new Error(ERR_INVALID_GINDEX);
+    }
+    bitstring = gindex.toString(2);
   }
-  const bitstring = gindex.toString(2);
   let i = 1;
-  const next = (): IteratorResult<number, undefined> => {
+  const next = (): IteratorResult<Bit, undefined> => {
     if (i === bitstring.length) {
       return {done: true, value: undefined};
     }
-    const bit = Number(bitstring[i]);
+    const bit = Number(bitstring[i]) as Bit;
     i++;
     return {done: false, value: bit};
   }
   return {
     [Symbol.iterator]() {
       return {next}
-    },
-    totalBitLength(): number {
-      return bitstring.length;
     },
     remainingBitLength(): number {
       return bitstring.length - i;

--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -5,7 +5,7 @@ export function bitIndexBigInt(v: bigint): number {
   return v.toString(2).length - 1;
 }
 
-export function toGindex(index: bigint, depth: number): Gindex {
+export function toGindex(depth: number, index: bigint): Gindex {
   const anchor = BigInt(1) << BigInt(depth);
   if (index >= anchor) {
     throw new Error("index too large for depth");
@@ -13,7 +13,7 @@ export function toGindex(index: bigint, depth: number): Gindex {
   return anchor | index;
 }
 
-export function toGindexBitstring(index: bigint, depth: number): GindexBitstring {
+export function toGindexBitstring(depth: number, index: bigint): GindexBitstring {
   const str = index ? index.toString(2) : '';
   if (str.length > depth) {
     throw new Error("index too large for depth");
@@ -34,12 +34,12 @@ export function countToDepth(count: bigint): number {
 /**
  * Iterate through Gindexes at a certain depth
  */
-export function iterateAtDepth(startIndex: bigint, count: bigint, depth: number): Iterable<Gindex> {
+export function iterateAtDepth(depth: number, startIndex: bigint, count: bigint): Iterable<Gindex> {
   const anchor = BigInt(1) << BigInt(depth);
   if (startIndex + count >= anchor) {
     throw new Error("Too large for depth");
   }
-  let i = toGindex(startIndex, depth);
+  let i = toGindex(depth, startIndex);
   const last = i + count;
   return {
     [Symbol.iterator]() {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -113,7 +113,7 @@ export class Tree {
    * starting from the `startIndex`-indexed node
    * iterating through `count` nodes
    */
-  *iterateNodesAtDepth(startIndex: number, count: number, depth: number): IterableIterator<Node> {
+  *iterateNodesAtDepth(depth: number, startIndex: number, count: number): IterableIterator<Node> {
     // Strategy:
     // First nagivate to the starting Gindex node,
     // At each level record the tuple (current node, the navigation direction) in a list (Left=0, Right=1)
@@ -142,7 +142,7 @@ export class Tree {
     }
     let node = this.rootNode;
     let currCount = 0;
-    const startGindex = toGindexBitstring(BigInt(startIndex), depth);
+    const startGindex = toGindexBitstring(depth, BigInt(startIndex));
     const nav: [Node, Bit][] = [];
     for (const i of gindexIterator(startGindex)) {
       nav.push([node, i]);

--- a/test/gindex.test.ts
+++ b/test/gindex.test.ts
@@ -26,15 +26,15 @@ describe("bigIndexBigInt", () => {
     }
 });
 
-describe("iterateAtDelth", () => {
+describe("iterateAtDepth", () => {
   const testCases: {
-    input: [bigint, bigint, number];
+    input: [number, bigint, bigint];
     expected: bigint[];
   }[] = [
-    {input: [BigInt(0), BigInt(0), 3], expected: []},
-    {input: [BigInt(0), BigInt(1), 3], expected: [BigInt(8)]},
-    {input: [BigInt(1), BigInt(1), 3], expected: [BigInt(9)]},
-    {input: [BigInt(1), BigInt(2), 3], expected: [BigInt(9), BigInt(10)]},
+    {input: [3, BigInt(0), BigInt(0)], expected: []},
+    {input: [3, BigInt(0), BigInt(1)], expected: [BigInt(8)]},
+    {input: [3, BigInt(1), BigInt(1)], expected: [BigInt(9)]},
+    {input: [3, BigInt(1), BigInt(2)], expected: [BigInt(9), BigInt(10)]},
   ];
   for (const {input, expected} of testCases) {
     it(`should correctly iterate at depth`, () => {

--- a/test/tree.test.ts
+++ b/test/tree.test.ts
@@ -2,16 +2,16 @@ import { expect } from "chai";
 
 import { Tree, zeroNode, LeafNode, subtreeFillToContents } from "../src";
 
-describe("tree fast iteration", () => {
+describe("fixed-depth tree iteration", () => {
   it("should properly navigate the zero tree", () => {
     const depth = 4;
     const zero = zeroNode(0).root;
     const tree = new Tree(zeroNode(4));
-    for (const n of tree.iterateNodesAtDepth(BigInt(0), BigInt(4), depth)) {
+    for (const n of tree.iterateNodesAtDepth(depth, 0, 4)) {
       expect(n.root).to.be.deep.equal(zero);
     }
     const one = zeroNode(1).root;
-    for (const n of tree.iterateNodesAtDepth(BigInt(0), BigInt(4), depth-1)) {
+    for (const n of tree.iterateNodesAtDepth(depth-1, 0, 4)) {
       expect(n.root).to.be.deep.equal(one);
     }
   });
@@ -26,7 +26,7 @@ describe("tree fast iteration", () => {
     for (let i = 0; i < length; i++) {
       for (let j = length - i - 1; j > 1; j--) {
         let k = i;
-        for (const n of tree.iterateNodesAtDepth(BigInt(i), BigInt(j), depth)) {
+        for (const n of tree.iterateNodesAtDepth(depth, i, j)) {
           expect(n.root).to.be.deep.equal(leaves[k].root);
           k++;
         }

--- a/test/tree.test.ts
+++ b/test/tree.test.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+
+import { Tree, zeroNode, LeafNode, subtreeFillToContents } from "../src";
+
+describe("tree fast iteration", () => {
+  it("should properly navigate the zero tree", () => {
+    const depth = 4;
+    const zero = zeroNode(0).root;
+    const tree = new Tree(zeroNode(4));
+    for (const n of tree.iterateNodesAtDepth(BigInt(0), BigInt(4), depth)) {
+      expect(n.root).to.be.deep.equal(zero);
+    }
+    const one = zeroNode(1).root;
+    for (const n of tree.iterateNodesAtDepth(BigInt(0), BigInt(4), depth-1)) {
+      expect(n.root).to.be.deep.equal(one);
+    }
+  });
+  it("should properly navigate a custom tree", () => {
+    const depth = 4
+    const length = 1 << depth;
+    const leaves = Array.from({length: length}, (_, i) => new LeafNode(Buffer.alloc(32, i)));
+    const tree = new Tree(subtreeFillToContents(leaves, depth));
+    // i = startIx
+    // j = count
+    // k = currentIx
+    for (let i = 0; i < length; i++) {
+      for (let j = length - i - 1; j > 1; j--) {
+        let k = i;
+        for (const n of tree.iterateNodesAtDepth(BigInt(i), BigInt(j), depth)) {
+          expect(n.root).to.be.deep.equal(leaves[k].root);
+          k++;
+        }
+        expect(k-i, `startIx=${i} count=${j} currIx=${k}`).to.be.eql(j);
+      }
+    }
+  })
+});


### PR DESCRIPTION
- Simplfy `gindexIterator`
  - add more precise iterator type (`Bit`)
  - allow for `Gindex | GindexBitstring` input
  - remove unused method (`totalBitLength`)
- Add `iterateNodesAtDepth`
  - Fast iteration of nodes at a depth w/o requiring recalculation of gindices or navigation from the root node for each iteration
  - First node is navigated to, storing the path thru the tree, the path is used to reference direct parent nodes, is popped/pushed to aid navigation thru the tree w/ fewer navigation steps
  - NOTE: this is meant for read-only iteration thru the tree
- Rearrange params, move `depth` to the first param where appropriate
  - effected functions: `toGindex`, `toGindexBitString`, `iterateAtDepth`, `Tree#iterateNodesAtDepth`

This has been linked against a modified modified version of ssz+lodestar, locally, for good results