### PR TITLE
Fix subtreeFillToContents edgecases

### DIFF
--- a/src/subtree.ts
+++ b/src/subtree.ts
@@ -39,15 +39,16 @@ export function subtreeFillToLength(bottom: Node, depth: number, length: number)
 }
 
 export function subtreeFillToContents(nodes: Node[], depth: number): Node {
-  const maxLength = 1 << depth;
+  const maxLength = 2 ** depth;
   if (nodes.length > maxLength) throw new Error(ERR_TOO_MANY_NODES);
   else if (depth === 0) {
-    if (nodes.length === 1) return nodes[0];
-    else throw new Error(ERR_NAVIGATION);
+    if (!nodes.length) return zeroNode(0);
+    return nodes[0];
   } else if (depth === 1) {
-    return new BranchNode(nodes[0], (nodes.length > 1) ? nodes[1] : zeroNode(0));
+    if (!nodes.length) return zeroNode(1);
+    return new BranchNode(nodes[0], nodes[1] || zeroNode(0));
   } else {
-    const pivot = maxLength >> 1;
+    const pivot = Math.floor(maxLength / 2);
     if (nodes.length <= pivot) {
       return new BranchNode(subtreeFillToContents(nodes, depth - 1), zeroNode(depth - 1));
     } else {

--- a/test/subtree.test.ts
+++ b/test/subtree.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+
+import { subtreeFillToContents, LeafNode } from "../src";
+
+describe("subtreeFillToContents", () => {
+  it("should not error on contents length 1", () => {
+    try {
+      subtreeFillToContents([new LeafNode(new Uint8Array(32))], 1);
+    } catch (e) {
+      expect.fail(e);
+    }
+  });
+  
+  it("should not error on empty contents", () => {
+    try {
+      subtreeFillToContents([], 0);
+      subtreeFillToContents([], 1);
+    } catch (e) {
+      expect.fail(e);
+    }
+  });
+  
+  it("should not error on depth 31", () => {
+    try {
+      subtreeFillToContents([], 31);
+    } catch (e) {
+      expect.fail(e);
+    }
+  })
+});


### PR DESCRIPTION
the `subtreeFillToContents` is a helper to create a tree given an array of leaf nodes. It fills up any remaining part of the tree with zero data.

two cases:
- empty contents -- should just use zero data in that case instead of erroring
- depth <= 31 - using bitshifts will break after this -- use integer arithmetic instead

testcases added to show these cases now working (previously failing)