### PR TITLE
Add tree traversal methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ const subtree: Tree = tree.getSubtree(gindex); // the Tree wrapping the Node at 
 
 const proof: Uint8Array[] = tree.getSingleProof(gindex);
 
+// A Tree can be traversed - PreOrder, PostOrder, InOrder
+
+for (const [node, gindex] of tree.traversePreOrder()) {
+  ...
+}
+
+// A Tree can also be traversed at a fixed depth
+
+for (const node of tree.iterateNodesAtDepth(depth, startIndex, count)) {
+  ...
+}
 ```
 
 ## Motivation

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -182,4 +182,123 @@ export class Tree {
       } while (nav.length && nav.length !== depth);
     }
   }
+
+  /**
+   * Read-only tree traversal - pre-order
+   */
+  *traversePreOrder(): IterableIterator<[Node, Gindex]> {
+    let node = this.rootNode;
+    let nodeDirection: Bit = 0;
+    const nav: [Node, Bit][] = [];
+    do {
+      yield [
+        node,
+        BigInt("0b1" + nav.map((v) => v[1]).join("")),
+      ];
+
+      if (!node.isLeaf()) {
+        nav.push([node, nodeDirection]);
+        if (!nodeDirection) {
+          node = node.left;
+        } else {
+          node = node.right;
+          nodeDirection = 0;
+        }
+      } else {
+        let parentNode;
+        let parentDirection;
+        do {
+          [parentNode, parentDirection] = nav.pop()!;
+        } while (parentDirection && nav.length);
+        if (!parentDirection) {
+          nav.push([parentNode, 1]);
+          node = parentNode.right;
+          nodeDirection = 0;
+        }
+      }
+    } while(nav.length);
+  }
+
+  /**
+   * Read-only tree traversal - post-order
+   */
+  *traversePostOrder(): IterableIterator<[Node, Gindex]> {
+    let node = this.rootNode;
+    let nodeDirection: Bit = 0;
+    const nav: [Node, Bit][] = [];
+    do {
+      if (!node.isLeaf()) {
+        nav.push([node, nodeDirection]);
+        if (!nodeDirection) {
+          node = node.left;
+        } else {
+          node = node.right;
+          nodeDirection = 0;
+        }
+      } else {
+        yield [
+          node,
+          BigInt("0b1" + nav.map((v) => v[1]).join("")),
+        ];
+        let parentNode;
+        let parentDirection;
+        do {
+          [parentNode, parentDirection] = nav.pop()!;
+          if (parentDirection) {
+            yield [
+              parentNode,
+              BigInt("0b1" + nav.map((v) => v[1]).join("")),
+            ];
+          }
+        } while (parentDirection && nav.length);
+        if (!parentDirection) {
+          nav.push([parentNode, 1]);
+          node = parentNode.right;
+          nodeDirection = 0;
+        }
+      }
+    } while(nav.length);
+  }
+
+  /**
+   * Read-only tree traversal - in-order
+   */
+  *traverseInOrder(): IterableIterator<[Node, Gindex]> {
+    let node = this.rootNode;
+    let nodeDirection: Bit = 0;
+    const nav: [Node, Bit][] = [];
+    do {
+      if (!node.isLeaf()) {
+        nav.push([node, nodeDirection]);
+        if (!nodeDirection) {
+          node = node.left;
+        } else {
+          node = node.right;
+          nodeDirection = 0;
+        }
+      } else {
+        yield [
+          node,
+          BigInt("0b1" + nav.map((v) => v[1]).join("")),
+        ];
+        let parentNode;
+        let parentDirection;
+        do {
+          [parentNode, parentDirection] = nav.pop()!;
+          if (!parentDirection) {
+            yield [
+              parentNode,
+              BigInt("0b1" + nav.map((v) => v[1]).join("")),
+            ];
+          }
+        } while (parentDirection && nav.length);
+        if (!parentDirection) {
+          nav.push([parentNode, 1]);
+          node = parentNode.right;
+          nodeDirection = 0;
+        }
+      }
+    } while(nav.length);
+  }
+
 }

--- a/test/tree.test.ts
+++ b/test/tree.test.ts
@@ -34,4 +34,31 @@ describe("fixed-depth tree iteration", () => {
       }
     }
   })
+  it("should properly traversePreOrder", () => {
+    const depth = 2
+    const length = 1 << depth;
+    const leaves = Array.from({length: length}, (_, i) => new LeafNode(Buffer.alloc(32, i)));
+    const tree = new Tree(subtreeFillToContents(leaves, depth));
+    const expectedPreOrderIndices = [1, 2, 4, 5, 3, 6, 7];
+    const actualPreOrderIndices = Array.from(tree.traversePreOrder()).map(([_, gindex]) => Number(gindex));
+    expect(actualPreOrderIndices).to.deep.equal(expectedPreOrderIndices);
+  });
+  it("should properly traversePostOrder", () => {
+    const depth = 2
+    const length = 1 << depth;
+    const leaves = Array.from({length: length}, (_, i) => new LeafNode(Buffer.alloc(32, i)));
+    const tree = new Tree(subtreeFillToContents(leaves, depth));
+    const expectedPreOrderIndices = [4, 5, 2, 6, 7, 3, 1];
+    const actualPreOrderIndices = Array.from(tree.traversePostOrder()).map(([_, gindex]) => Number(gindex));
+    expect(actualPreOrderIndices).to.deep.equal(expectedPreOrderIndices);
+  });
+  it("should properly traverseInOrder", () => {
+    const depth = 2
+    const length = 1 << depth;
+    const leaves = Array.from({length: length}, (_, i) => new LeafNode(Buffer.alloc(32, i)));
+    const tree = new Tree(subtreeFillToContents(leaves, depth));
+    const expectedPreOrderIndices = [4, 2, 5, 1, 6, 3, 7];
+    const actualPreOrderIndices = Array.from(tree.traverseInOrder()).map(([_, gindex]) => Number(gindex));
+    expect(actualPreOrderIndices).to.deep.equal(expectedPreOrderIndices);
+  });
 });


### PR DESCRIPTION
Add `Tree#traversePreOrder`, `Tree#traversePostOrder`, `Tree#traverseInOrder` and example in README

See https://en.wikipedia.org/wiki/Tree_traversal#Depth-first_search_of_binary_tree