### PR TITLE
Add concatGindices

### DIFF
--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -96,3 +96,12 @@ export function gindexIterator(gindex: Gindex | GindexBitstring): GindexIterator
     },
   }
 }
+
+/**
+ * Concatenate Generalized Indices
+ * Given generalized indices i1 for A -> B, i2 for B -> C .... i_n for Y -> Z, returns
+ * the generalized index for A -> Z.
+ */
+export function concatGindices(gindices: Gindex[]): Gindex {
+  return BigInt(gindices.reduce((acc, gindex) => acc + gindex.toString(2).slice(1), "0b1"));
+}

--- a/test/gindex.test.ts
+++ b/test/gindex.test.ts
@@ -1,6 +1,6 @@
 import {assert, expect} from "chai";
 import {describe, it} from "mocha";
-import {countToDepth, bitIndexBigInt, iterateAtDepth} from "../src";
+import {countToDepth, bitIndexBigInt, iterateAtDepth, Gindex, concatGindices} from "../src";
 
 describe("countToDepth", () => {
     const testCases = [
@@ -43,3 +43,21 @@ describe("iterateAtDepth", () => {
     });
   }
 })
+
+describe("concatGindices", () => {
+  const testCases: {
+    input: Gindex[];
+    expected: Gindex;
+  }[] = [
+    // cases calculated by hand
+    {input: [BigInt(2), BigInt(3)], expected: BigInt(5)},
+    {input: [BigInt(31), BigInt(3)], expected: BigInt(63)},
+    {input: [BigInt(31), BigInt(6)], expected: BigInt(126)},
+  ];
+  for (const {input, expected} of testCases) {
+    it(`should correctly concatenate gindices`, () => {
+      const actual = concatGindices(input);
+      expect(actual).to.equal(expected);
+    })
+  }
+});


### PR DESCRIPTION
Add function to concatenate generalized indices.
Uses the binary string representation to avoid slower BigInt arithmetic.

This will be used to help calculate the gindex of an ssz path.
Eg: To calculate the gindex of state.validators[n].effectiveBalance
A = BeaconState.gindexOfProperty("validators")
B = Validators.gindexOfProperty(n)
C = Validator.gindexOfProperty("effectiveBalance")
concatGindices([A, B, C])