### PR TITLE
Fix off-by-one in iterateAtDepth

### DIFF
--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -36,7 +36,7 @@ export function countToDepth(count: bigint): number {
  */
 export function iterateAtDepth(depth: number, startIndex: bigint, count: bigint): Iterable<Gindex> {
   const anchor = BigInt(1) << BigInt(depth);
-  if (startIndex + count >= anchor) {
+  if (startIndex + count > anchor) {
     throw new Error("Too large for depth");
   }
   let i = toGindex(depth, startIndex);

--- a/test/gindex.test.ts
+++ b/test/gindex.test.ts
@@ -53,9 +53,10 @@ describe("iterateAtDepth", () => {
     {input: [3, BigInt(0), BigInt(1)], expected: [BigInt(8)]},
     {input: [3, BigInt(1), BigInt(1)], expected: [BigInt(9)]},
     {input: [3, BigInt(1), BigInt(2)], expected: [BigInt(9), BigInt(10)]},
+    {input: [3, BigInt(0), BigInt(8)], expected: [BigInt(8), BigInt(9), BigInt(10), BigInt(11), BigInt(12), BigInt(13), BigInt(14), BigInt(15)]},
   ];
   for (const {input, expected} of testCases) {
-    it(`should correctly iterate at depth`, () => {
+    it(`should correctly iterate at depth=${input[0]} start=${input[1]} count=${input[2]}`, () => {
       const actual = Array.from(iterateAtDepth(input[0], input[1], input[2]));
       expect(actual).to.deep.equal(expected);
     });


### PR DESCRIPTION
**Motivation**

Investigating "Too large for depth" error seen in Lodestar

**Description**

`iterateAtDepth` incorrectly throws on iterating from `startIndex = 0, count = 2 ** depth` due to an off-by-one error in the check for iterating past the depth.

**Steps to test or reproduce**

See added test case
