### PR TITLE
Use singleton uint8array for hash

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,8 +1,12 @@
 import SHA256 from "@chainsafe/as-sha256";
 
+const input = new Uint8Array(64);
+
 /**
  * Hash two 32 byte arrays
  */
 export function hash(a: Uint8Array, b: Uint8Array): Uint8Array {
-  return SHA256.digest64(Buffer.concat([a, b]));
+  input.set(a, 0);
+  input.set(b, 32);
+  return SHA256.digest64(input);
 }


### PR DESCRIPTION
**Motivation**

Using Buffer.concat results in errors (in the browser) if the list is not a list of Buffers.

Using Uint8Array directly is simpler and less-error-prone.