### PR TITLE
Support GindexBitstring in Tree APIs

### DIFF
--- a/src/gindex.ts
+++ b/src/gindex.ts
@@ -13,8 +13,8 @@ export function toGindex(depth: number, index: bigint): Gindex {
   return anchor | index;
 }
 
-export function toGindexBitstring(depth: number, index: bigint): GindexBitstring {
-  const str = index ? index.toString(2) : "";
+export function toGindexBitstring(depth: number, index: number): GindexBitstring {
+  const str = index ? Number(index).toString(2) : "";
   if (str.length > depth) {
     throw new Error("index too large for depth");
   } else {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,4 +1,4 @@
-import {Gindex, gindexIterator, Bit, toGindexBitstring} from "./gindex";
+import {Gindex, gindexIterator, Bit, toGindexBitstring, GindexBitstring} from "./gindex";
 import {Node, BranchNode, Link, compose, identity, LeafNode} from "./node";
 import {createNodeFromProof, createProof, Proof, ProofInput} from "./proof";
 import {createSingleProof} from "./proof/single";
@@ -57,7 +57,7 @@ export class Tree {
     return this.rootNode.root;
   }
 
-  getNode(index: Gindex): Node {
+  getNode(index: Gindex | GindexBitstring): Node {
     let node = this.rootNode;
     for (const i of gindexIterator(index)) {
       if (i) {
@@ -71,7 +71,7 @@ export class Tree {
     return node;
   }
 
-  setter(index: Gindex, expand = false): Link {
+  setter(index: Gindex | GindexBitstring, expand = false): Link {
     let link = identity;
     let node = this.rootNode;
     const iterator = gindexIterator(index);
@@ -101,23 +101,23 @@ export class Tree {
     return compose(identity, link);
   }
 
-  setNode(index: Gindex, n: Node, expand = false): void {
+  setNode(index: Gindex | GindexBitstring, n: Node, expand = false): void {
     this.rootNode = this.setter(index, expand)(n);
   }
 
-  getRoot(index: Gindex): Uint8Array {
+  getRoot(index: Gindex | GindexBitstring): Uint8Array {
     return this.getNode(index).root;
   }
 
-  setRoot(index: Gindex, root: Uint8Array, expand = false): void {
+  setRoot(index: Gindex | GindexBitstring, root: Uint8Array, expand = false): void {
     this.setNode(index, new LeafNode(root), expand);
   }
 
-  getSubtree(index: Gindex): Tree {
+  getSubtree(index: Gindex | GindexBitstring): Tree {
     return new Tree(this.getNode(index), (v: Tree): void => this.setNode(index, v.rootNode));
   }
 
-  setSubtree(index: Gindex, v: Tree, expand = false): void {
+  setSubtree(index: Gindex | GindexBitstring, v: Tree, expand = false): void {
     this.setNode(index, v.rootNode, expand);
   }
 
@@ -168,7 +168,7 @@ export class Tree {
 
     let node = this.rootNode;
     let currCount = 0;
-    const startGindex = toGindexBitstring(depth, BigInt(startIndex));
+    const startGindex = toGindexBitstring(depth, startIndex);
     const nav: [Node, Bit][] = [];
     for (const i of gindexIterator(startGindex)) {
       nav.push([node, i]);

--- a/test/perf/tree.perf.ts
+++ b/test/perf/tree.perf.ts
@@ -1,0 +1,60 @@
+import { itBench, setBenchOpts } from "@dapplion/benchmark";
+import { LeafNode, subtreeFillToContents, Node, countToDepth, Tree, toGindex, toGindexBitstring } from "../../src";
+
+describe("Track the performance of different Tree methods", () => {
+  setBenchOpts({
+    maxMs: 60 * 1000,
+    minMs: 30 * 1000,
+    runs: 10,
+  });
+
+  const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+  // add 1 to countToDepth for mix_in_length spec
+  const depth = countToDepth(BigInt(Math.ceil(VALIDATOR_REGISTRY_LIMIT / 4))) + 1;
+
+  const newRoot = new Uint8Array(Array.from({length: 32}, () => 1));
+  const numBalance = 250_000;
+  const index = Math.floor(125_000 / 4);
+  const gindex = toGindex(depth, BigInt(index));
+  const gindexBitstring = toGindexBitstring(depth, index);
+
+  const numLoop = 10_000;
+
+  const tree = new Tree(createBalanceList(numBalance, depth));
+  /** Using gindexBitstring is 5% faster than using gindex */
+  itBench("setRoot for balances tree using gindexBitstring", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.setRoot(gindexBitstring, newRoot);
+    }
+  });
+
+  itBench("setRoot for balances tree using gindex", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.setRoot(gindex, newRoot);
+    }
+  });
+
+  /** Using gindexBitstring is 10% faster than using gindex */
+  itBench("getRoot for balances tree using gindexBitstring", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.getRoot(gindexBitstring);
+    }
+  });
+
+  itBench("getRoot for balances tree using gindex", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.getRoot(gindex);
+    }
+  });
+});
+
+function createBalanceList(count: number, depth: number): Node {
+  // each balance has 2 bytes => each chunk contains 4 balance
+  const numChunk = Math.ceil(count / 4);
+  const nodes: Node[] = [];
+  for (let i = 0; i < numChunk; i++) {
+    nodes.push(new LeafNode(new Uint8Array(Array.from({length: 32}, () => (i % 10)))));
+  }
+
+  return subtreeFillToContents(nodes, depth);
+}


### PR DESCRIPTION
**Motivation**

+ Gindex is bigint, it's better to use GindexBitstring to save an bigint allocation
+ `gindexIterator` already supports `GindexBitstring`, we'll convert to `GindexBitstring` in the end

**Description**
+ Support `gindex.toString(2)` in Tree APIs
+ SSZ should switch to use `GindexBitstring` whenever possible