### PR TITLE
Add bigint-backed Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@chainsafe/as-sha256": "^0.2.2"
+    "@chainsafe/as-sha256": "^0.2.2",
+    "bigint-buffer": "^1.1.5",
+    "bigint-hash": "^0.2.2"
   }
 }

--- a/src/bigint.ts
+++ b/src/bigint.ts
@@ -1,0 +1,17 @@
+import {toBufferBE, toBigIntBE} from "bigint-buffer";
+import {getHasher, HashType} from "bigint-hash";
+
+export function bigIntToUint8Array(a: bigint): Uint8Array {
+  return new Uint8Array(toBufferBE(a, 32));
+}
+
+export function uint8ArrayToBigInt(a: Uint8Array): bigint {
+  return toBigIntBE(Buffer.from(a));
+}
+
+export function hashBigInt(a: bigint, b: bigint): bigint {
+  const input = Buffer.allocUnsafe(64);
+  input.set(bigIntToUint8Array(a), 0);
+  input.set(bigIntToUint8Array(b), 32);
+  return getHasher(HashType.SHA256).update(input).digestBigInt();
+}

--- a/src/nodeBigint.ts
+++ b/src/nodeBigint.ts
@@ -1,0 +1,120 @@
+import {bigIntToUint8Array, hashBigInt, uint8ArrayToBigInt} from "./bigint";
+
+const ERR_INVALID_TREE = "Invalid tree";
+const ERR_NOT_IMPLEMENTED = "Not implemented";
+
+export abstract class Node {
+  get rootBigInt(): bigint {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  get root(): Uint8Array {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  isLeaf(): boolean {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  get left(): Node {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  get right(): Node {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  rebindLeft(left: Node): Node {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  rebindRight(right: Node): Node {
+    throw new Error(ERR_NOT_IMPLEMENTED);
+  }
+}
+
+export class BranchNode extends Node {
+  private _rootBigInt: bigint | null = null;
+
+  constructor(private _left: Node, private _right: Node) {
+    super();
+    if (!_left || !_right) throw new Error(ERR_INVALID_TREE);
+  }
+
+  get rootBigInt(): bigint {
+    if (!this._rootBigInt) {
+      this._rootBigInt = hashBigInt(this.left.rootBigInt, this.right.rootBigInt);
+    }
+    return this._rootBigInt as bigint;
+  }
+
+  get root(): Uint8Array {
+    return bigIntToUint8Array(this.rootBigInt);
+  }
+
+  isLeaf(): boolean {
+    return false;
+  }
+
+  get left(): Node {
+    return this._left;
+  }
+
+  set left(n: Node) {
+    this._left = n;
+  }
+
+  get right(): Node {
+    return this._right;
+  }
+
+  set right(n: Node) {
+    this._right = n;
+  }
+
+  rebindLeft(left: Node): Node {
+    return new BranchNode(left, this.right);
+  }
+
+  rebindRight(right: Node): Node {
+    return new BranchNode(this.left, right);
+  }
+}
+
+export class LeafNode extends Node {
+  private _rootBigInt: bigint;
+
+  constructor(_root: Uint8Array) {
+    super();
+    if (_root.length !== 32) throw new Error(ERR_INVALID_TREE);
+    this._rootBigInt = uint8ArrayToBigInt(_root);
+  }
+
+  get rootBigInt(): bigint {
+    return this._rootBigInt;
+  }
+
+  get root(): Uint8Array {
+    return bigIntToUint8Array(this._rootBigInt);
+  }
+
+  isLeaf(): boolean {
+    return true;
+  }
+}
+
+// setter helpers
+
+export type Link = (n: Node) => Node;
+
+export function identity(n: Node): Node {
+  return n;
+}
+
+export function compose(inner: Link, outer: Link): Link {
+  return function (n: Node): Node {
+    return outer(inner(n));
+  };
+}

--- a/test/nodeBigint.test.ts
+++ b/test/nodeBigint.test.ts
@@ -1,0 +1,38 @@
+import {expect} from "chai";
+import * as N from "../src/node";
+import * as NBI from "../src/nodeBigint";
+
+describe("Node - BigInt", () => {
+  it("should hash nodes identically", () => {
+    const a = Buffer.alloc(32, 0);
+    a[0] = 255;
+    const b = Buffer.alloc(32, 1);
+    b[0] = 255;
+    const c = Buffer.alloc(32, 2);
+    c[0] = 255;
+    const d = Buffer.alloc(32, 3);
+    d[0] = 255;
+
+    const t1 = new N.BranchNode(
+      new N.BranchNode(
+        new N.LeafNode(a),
+        new N.LeafNode(b)
+      ),
+      new N.BranchNode(
+        new N.LeafNode(c),
+        new N.LeafNode(d)
+      )
+    );
+    const t2 = new NBI.BranchNode(
+      new NBI.BranchNode(
+        new NBI.LeafNode(a),
+        new NBI.LeafNode(b)
+      ),
+      new NBI.BranchNode(
+        new NBI.LeafNode(c),
+        new NBI.LeafNode(d)
+      )
+    );
+    expect(t2.root).to.deep.equal(t1.root);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,10 +462,33 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+bigint-buffer@^1.1.2, bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
+bigint-hash@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/bigint-hash/-/bigint-hash-0.2.2.tgz#6aa50a0d9a441ac37dcbfdb4913c44158740ae02"
+  integrity sha512-GKbYUs3tUurQUAPTdSVFHwiZJLfqOrNOehuIJ63ghOqHFUcv+h6eWgVdwYFjIehDTfPWrLHE57G5kzYfl/biqg==
+  dependencies:
+    bigint-buffer "^1.1.2"
+    bindings "^1.3.0"
+    xxhashjs "^0.2.2"
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 blob@0.0.5:
   version "0.0.5"
@@ -763,6 +786,11 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 custom-event@~1.0.0:
   version "1.0.1"
@@ -1285,6 +1313,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -3289,6 +3322,13 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/issues/2885

One strategy for lowering memory footprint of our merkle tree is to replace the many `Uint8Array`s of the tree with `BigInt`s.

**Description**

Add an additional Node/Branch/Leaf implementation that is backed by BigInt instead of Uint8Array.
Explore arising issues.

Notes / issues:
- The implementation is built _along side_ the existing implementation, and is not currently exported. It also isn't integrated into the subtree-generating code (eg: `sutbreeFillToDepth`). This is because the `bigint-buffer` and `bigint-hash` libraries don't work in the browser, but rely entirely on native bindings! We need to retain browser compatibility in this library to facilitate proof consumption and other browser use-cases.
  - Resolving this may take several forms:
    - improve `bigint-*` library browser compatibility
    - selectively export or use Uint8Array-backed Nodes vs BigInt-backed Nodes
    - Resolve all issues with BigInt-backed Nodes and fully remove Uint8Array-backed Nodes
- The `bigint-hash` library provides a hasher that can natively return a BigInt, however it does not currently accept a BigInt (or multiple BigInts) as _input_. Consequently, BigInt inputs must be converted/copied into a Buffer before hashing. This causes significant re-work and should be improved.