### PR TITLE
Optimize get nodes at depth

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -225,6 +225,89 @@ export class Tree {
     }
   }
 
+  /**
+   * Fast read-only iteration
+   * In-order traversal of nodes at `depth`
+   * starting from the `startIndex`-indexed node
+   * iterating through `count` nodes
+   */
+  getNodesAtDepth(depth: number, startIndex: number, count: number): Node[] {
+    // Strategy:
+    // First nagivate to the starting Gindex node,
+    // At each level record the tuple (current node, the navigation direction) in a list (Left=0, Right=1)
+    // Once we reach the starting Gindex node, the list will be length == depth
+    // Begin emitting nodes: Outer loop:
+    //   Yield the current node
+    //   Inner loop
+    //     pop off the end of the list
+    //     If its (N, Left) (we've nav'd the left subtree, but not the right subtree)
+    //       push (N, Right) and set set node as the n.right
+    //       push (N, Left) and set node as n.left until list length == depth
+    //   Inner loop until the list length == depth
+    // Outer loop until the list is empty or the yield count == count
+    if (startIndex < 0 || count < 0 || depth < 0) {
+      throw new Error(ERR_PARAM_LT_ZERO);
+    }
+
+    if (BigInt(1) << BigInt(depth) < startIndex + count) {
+      throw new Error(ERR_COUNT_GT_DEPTH);
+    }
+
+    if (count === 0) {
+      return [];
+    }
+
+    if (depth === 0) {
+      return [this.rootNode];
+    }
+
+    const nodes: Node[] = [];
+
+    let node = this.rootNode;
+    let currCount = 0;
+    const startGindex = toGindexBitstring(depth, BigInt(startIndex));
+    const nav: [Node, Bit][] = [];
+    for (const i of gindexIterator(startGindex)) {
+      nav.push([node, i]);
+      if (i) {
+        if (node.isLeaf()) throw new Error(ERR_INVALID_TREE);
+        node = node.right;
+      } else {
+        if (node.isLeaf()) throw new Error(ERR_INVALID_TREE);
+        node = node.left;
+      }
+    }
+
+    while (nav.length && currCount < count) {
+      nodes.push(node);
+
+      currCount++;
+      if (currCount === count) {
+        break;
+      }
+
+      do {
+        const [parentNode, direction] = nav.pop()!;
+        // if direction was left
+        if (!direction) {
+          // now navigate right
+          nav.push([parentNode, 1]);
+          if (parentNode.isLeaf()) throw new Error(ERR_INVALID_TREE);
+          node = parentNode.right;
+
+          // and then left as far as possible
+          while (nav.length !== depth) {
+            nav.push([node, 0]);
+            if (node.isLeaf()) throw new Error(ERR_INVALID_TREE);
+            node = node.left;
+          }
+        }
+      } while (nav.length && nav.length !== depth);
+    }
+
+    return nodes;
+  }
+
   getProof(input: ProofInput): Proof {
     return createProof(this.rootNode, input);
   }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -270,7 +270,7 @@ export class Tree {
 
     let node = this.rootNode;
     let currCount = 0;
-    const startGindex = toGindexBitstring(depth, BigInt(startIndex));
+    const startGindex = toGindexBitstring(depth, startIndex);
     const nav: [Node, Bit][] = [];
     for (const i of gindexIterator(startGindex)) {
       nav.push([node, i]);

--- a/test/perf/tree.test.ts
+++ b/test/perf/tree.test.ts
@@ -1,7 +1,7 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {Tree, subtreeFillToDepth, BranchNode, iterateAtDepth, LeafNode} from "../../src";
+import {Tree, subtreeFillToDepth, iterateAtDepth, LeafNode} from "../../src";
 
-describe("set", () => {
+describe("Tree", () => {
   setBenchOpts({
     maxMs: 60 * 1000,
     minMs: 1 * 1000,
@@ -16,6 +16,21 @@ describe("set", () => {
 
     itBench(`set at depth ${depth}`, () => {
       backing.setNode(gindex, n2);
+    });
+  }
+
+  for (const depth of [8, 16, 32]) {
+    const n = subtreeFillToDepth(new LeafNode(Buffer.alloc(32, 1)), depth);
+    const backing = new Tree(n);
+    const startIndex = 0;
+    const count = Math.min(250_000, 2 ** depth);
+
+    itBench(`iterateNodesAtDepth ${depth}`, () => {
+      Array.from(backing.iterateNodesAtDepth(depth, startIndex, count));
+    });
+
+    itBench(`getNodesAtDepth ${depth}`, () => {
+      backing.getNodesAtDepth(depth, startIndex, count);
     });
   }
 });

--- a/test/perf/tree.test.ts
+++ b/test/perf/tree.test.ts
@@ -19,17 +19,17 @@ describe("Tree", () => {
     });
   }
 
-  for (const depth of [8, 16, 32]) {
+  for (const depth of [8, 16, 32, 40]) {
     const n = subtreeFillToDepth(new LeafNode(Buffer.alloc(32, 1)), depth);
     const backing = new Tree(n);
     const startIndex = 0;
     const count = Math.min(250_000, 2 ** depth);
 
-    itBench(`iterateNodesAtDepth ${depth}`, () => {
+    itBench(`iterateNodesAtDepth ${depth} ${count}`, () => {
       Array.from(backing.iterateNodesAtDepth(depth, startIndex, count));
     });
 
-    itBench(`getNodesAtDepth ${depth}`, () => {
+    itBench(`getNodesAtDepth ${depth} ${count}`, () => {
       backing.getNodesAtDepth(depth, startIndex, count);
     });
   }


### PR DESCRIPTION
**Motivation**

Expose methods without iterators to grab all data

**Description**

Depends on https://github.com/ChainSafe/persistent-merkle-tree/pull/47

```
    ✓ iterateNodesAtDepth 8 256                                           22122.91 ops/s    45.20200 us/op        -      22004 runs   1.00 s
    ✓ getNodesAtDepth 8 256                                               85755.94 ops/s    11.66100 us/op        -      83874 runs   1.00 s
    ✓ iterateNodesAtDepth 16 65536                                        84.51882 ops/s    11.83169 ms/op        -       1024 runs   12.1 s
    ✓ getNodesAtDepth 16 65536                                            306.7791 ops/s    3.259675 ms/op        -       1024 runs   3.34 s
    ✓ iterateNodesAtDepth 32 250000                                       20.16633 ops/s    49.58761 ms/op        -       1024 runs   50.8 s
    ✓ getNodesAtDepth 32 250000                                           60.90587 ops/s    16.41878 ms/op        -       1024 runs   16.8 s
    ✓ iterateNodesAtDepth 40 250000                                       18.03835 ops/s    55.43744 ms/op        -       1024 runs   56.8 s
    ✓ getNodesAtDepth 40 250000                                           48.00627 ops/s    20.83061 ms/op        -       1024 runs   21.3 s
```