### PR TITLE
Expose HashObject interfaces

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -27,3 +27,8 @@ export function hashObjectToUint8Array(obj: HashObject): Uint8Array {
 export function uint8ArrayToHashObject(byteArr: Uint8Array): HashObject {
   return byteArrayToHashObject(byteArr);
 }
+
+export function isHashObject(hash: HashObject | Uint8Array): hash is HashObject {
+  // @ts-ignore
+  return hash.length === undefined;
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,5 @@
 import {HashObject} from "@chainsafe/as-sha256";
-import {hashObjectToUint8Array, hashTwoObjects, uint8ArrayToHashObject} from "./hash";
+import {hashObjectToUint8Array, hashTwoObjects, isHashObject, uint8ArrayToHashObject} from "./hash";
 
 const ERR_INVALID_TREE = "Invalid tree";
 
@@ -74,10 +74,14 @@ export class BranchNode extends Node {
 }
 
 export class LeafNode extends Node {
-  constructor(_root: Uint8Array) {
+  constructor(_root: Uint8Array | HashObject) {
     super();
-    if (_root.length !== 32) throw new Error(ERR_INVALID_TREE);
-    this.applyHash(uint8ArrayToHashObject(_root));
+    if (isHashObject(_root)) {
+      this.applyHash(_root);
+    } else {
+      if (_root.length !== 32) throw new Error(ERR_INVALID_TREE);
+      this.applyHash(uint8ArrayToHashObject(_root));
+    }
   }
 
   get rootHashObject(): HashObject {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,5 +1,6 @@
 import {Gindex, gindexIterator, Bit, toGindexBitstring, GindexBitstring} from "./gindex";
 import {Node, LeafNode} from "./node";
+import {HashObject} from "@chainsafe/as-sha256";
 import {createNodeFromProof, createProof, Proof, ProofInput} from "./proof";
 import {createSingleProof} from "./proof/single";
 import {zeroNode} from "./zeroNode";
@@ -130,11 +131,19 @@ export class Tree {
     return this.getNode(index).root;
   }
 
+  getHashObject(index: Gindex | GindexBitstring): HashObject {
+    return this.getNode(index);
+  }
+
   setRoot(index: Gindex | GindexBitstring, root: Uint8Array, expand = false): void {
     this.setNode(index, new LeafNode(root), expand);
   }
 
-  getSubtree(index: Gindex | GindexBitstring): Tree {
+  setHashObject(index: Gindex | GindexBitstring, hashObject: HashObject, expand = false): void {
+    this.setNode(index, new LeafNode(hashObject), expand);
+  }
+
+  getSubtree(index: Gindex): Tree {
     return new Tree(this.getNode(index), (v: Tree): void => this.setNode(index, v.rootNode));
   }
 

--- a/test/perf/tree.perf.ts
+++ b/test/perf/tree.perf.ts
@@ -1,5 +1,5 @@
 import { itBench, setBenchOpts } from "@dapplion/benchmark";
-import { LeafNode, subtreeFillToContents, Node, countToDepth, Tree, toGindex, toGindexBitstring } from "../../src";
+import { LeafNode, subtreeFillToContents, Node, countToDepth, Tree, toGindex, uint8ArrayToHashObject, toGindexBitstring } from "../../src";
 
 describe("Track the performance of different Tree methods", () => {
   setBenchOpts({
@@ -17,35 +17,51 @@ describe("Track the performance of different Tree methods", () => {
   const index = Math.floor(125_000 / 4);
   const gindex = toGindex(depth, BigInt(index));
   const gindexBitstring = toGindexBitstring(depth, index);
+  const newHashObject = uint8ArrayToHashObject(newRoot);
 
   const numLoop = 10_000;
-
+  /** May need to run these tests separately to compare the performance */
   const tree = new Tree(createBalanceList(numBalance, depth));
   /** Using gindexBitstring is 5% faster than using gindex */
-  itBench("setRoot for balances tree using gindexBitstring", () => {
+  itBench("setRoot - gindexBitstring", () => {
     for (let i = 0; i < numLoop; i++) {
       tree.setRoot(gindexBitstring, newRoot);
     }
   });
 
-  itBench("setRoot for balances tree using gindex", () => {
+  itBench("setRoot - gindex", () => {
     for (let i = 0; i < numLoop; i++) {
       tree.setRoot(gindex, newRoot);
     }
   });
 
   /** Using gindexBitstring is 10% faster than using gindex */
-  itBench("getRoot for balances tree using gindexBitstring", () => {
+  itBench("getRoot - gindexBitstring", () => {
     for (let i = 0; i < numLoop; i++) {
       tree.getRoot(gindexBitstring);
     }
   });
 
-  itBench("getRoot for balances tree using gindex", () => {
+  itBench("getRoot - gindex", () => {
     for (let i = 0; i < numLoop; i++) {
       tree.getRoot(gindex);
     }
   });
+
+  // 5% faster than getRoot
+  itBench("getHashObject - gindex", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.getHashObject(gindex);
+    }
+  });
+
+  // 15% faster than setRoot
+  itBench("setHashObject - gindex", () => {
+    for (let i = 0; i < numLoop; i++) {
+      tree.setHashObject(gindex, newHashObject);
+    }
+  });
+
 });
 
 function createBalanceList(count: number, depth: number): Node {

--- a/test/unit/tree.test.ts
+++ b/test/unit/tree.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {Tree, zeroNode, LeafNode, subtreeFillToContents, iterateAtDepth} from "../../src";
+import {Tree, zeroNode, LeafNode, subtreeFillToContents, uint8ArrayToHashObject} from "../src";
 
 describe("fixed-depth tree iteration", () => {
   it("should properly navigate the zero tree", () => {
@@ -38,15 +38,19 @@ describe("fixed-depth tree iteration", () => {
 });
 
 describe("subtree mutation", () => {
-  it("changing a subtree should change the parent root", () => {
+  let tree: Tree;
+  beforeEach(() => {
     const depth = 2;
-    const tree = new Tree(zeroNode(depth));
+    tree = new Tree(zeroNode(depth));
     // Get the subtree with "X"s
     //       0
     //      /  \
     //    0      X
     //   / \    / \
     //  0   0  X   X
+  });
+
+  it("changing a subtree should change the parent root", () => {
     const subtree = tree.getSubtree(BigInt(3));
 
     const rootBefore = tree.root;
@@ -54,6 +58,16 @@ describe("subtree mutation", () => {
     const rootAfter = tree.root;
 
     expect(toHex(rootBefore)).to.not.equal(rootAfter);
+  });
+
+  it("setRoot vs setHashObject", () => {
+    const newRoot = new Uint8Array(Array.from({length: 32}, () => 1));
+    const newHashObject = uint8ArrayToHashObject(newRoot);
+    const tree1 = tree.clone();
+    tree1.setRoot(BigInt(4), newRoot);
+    const tree2 = tree.clone();
+    tree2.setHashObject(BigInt(4), newHashObject);
+    expect(toHex(tree1.root)).to.be.equal(toHex(tree2.root));
   });
 });
 

--- a/test/unit/tree.test.ts
+++ b/test/unit/tree.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {Tree, zeroNode, LeafNode, subtreeFillToContents, uint8ArrayToHashObject} from "../src";
+import {Tree, zeroNode, LeafNode, subtreeFillToContents, uint8ArrayToHashObject} from "../../src";
 
 describe("fixed-depth tree iteration", () => {
   it("should properly navigate the zero tree", () => {


### PR DESCRIPTION
**Motivation**

We want ssz to work with HashObject directly without going through intermediate Uint8Array objects, that would improve performance and save some memory

**Description**

+ For APIs accepting a Uint8Array, we add same version with HashObject. For example `getRoot vs getHashObject`, `setRoot vs setHashObject` etc.

Part of https://github.com/ChainSafe/ssz/issues/156
