### PR TITLE
getSubTree to support GindexBitstring

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -129,7 +129,7 @@ export class Tree {
     this.rebindNodeToRoot(bitstring, parentNodes, newNode);
   }
 
-  getSubtree(index: Gindex): Tree {
+  getSubtree(index: Gindex | GindexBitstring): Tree {
     return new Tree(this.getNode(index), (v: Tree): void => this.setNode(index, v.rootNode));
   }
 


### PR DESCRIPTION
**Motivation**

We want to support gindexbitstring in `getSubTree` api so that it'll be used in ssz to avoid having to parse gIndex to gindexbitstring